### PR TITLE
feat: Add `--text-item-prefix` option in text mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ php-dep path/to/your/file.php --format=json
 
 # Output in Markdown format to a file
 php-dep path/to/your/file.php --output=dependencies.md
+
+# Output in text format with custom prefix
+php-dep path/to/your/file.php --format=text --text-item-prefix="@"
+
+# Output in text format without prefix
+php-dep path/to/your/file.php --format=text --text-item-prefix=""
 ```
 
 ### Library Usage

--- a/bin/php-dep
+++ b/bin/php-dep
@@ -42,6 +42,7 @@ $analyzeCommand = $application->register('analyze')
     ->addOption('composer', 'c', InputOption::VALUE_REQUIRED, 'Path to composer.json file')
     ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Output file path (for markdown format)')
     ->addOption('include-autoload', 'a', InputOption::VALUE_NONE, 'Include autoload.php in the analysis (default: false)')
+    ->addOption('text-item-prefix', null, InputOption::VALUE_REQUIRED, 'Prefix for each dependency line in text output format (default: "  - ")', '  - ')
     ->setCode(function (InputInterface $input, OutputInterface $output) {
         $filePath = $input->getArgument('file');
         $recursive = true; // Always recursive by default
@@ -49,6 +50,7 @@ $analyzeCommand = $application->register('analyze')
         $composerJsonPath = $input->getOption('composer');
         $outputFilePath = $input->getOption('output');
         $includeAutoload = $input->getOption('include-autoload');
+        $textItemPrefix = $input->getOption('text-item-prefix');
         
         try {
             // Create a parser
@@ -97,7 +99,7 @@ $analyzeCommand = $application->register('analyze')
                     $output->writeln('  <comment>No dependencies found.</comment>');
                 } else {
                     foreach ($dependencies as $dependency) {
-                        $output->writeln("  - {$dependency}");
+                        $output->writeln("{$textItemPrefix}{$dependency}");
                     }
                     
                     $output->writeln("\n<info>Total dependencies: " . count($dependencies) . "</info>");

--- a/tests/CliOutputTest.php
+++ b/tests/CliOutputTest.php
@@ -142,4 +142,88 @@ class CliOutputTest extends TestCase
             }
         }
     }
+
+    /**
+     * Test text output with custom item prefix
+     */
+    public function testTextOutputWithCustomPrefix()
+    {
+        // Create a temporary directory for test files
+        $tempDir = sys_get_temp_dir() . '/php-dep-test-' . uniqid();
+        mkdir($tempDir, 0755, true);
+        
+        try {
+            // Create test files
+            $mainFile = $tempDir . '/main.php';
+            $depFile = $tempDir . '/dependency.php';
+            
+            file_put_contents($mainFile, '<?php require_once "dependency.php"; echo "Main file"; ?>');
+            file_put_contents($depFile, '<?php echo "Dependency file"; ?>');
+            
+            $customCommand = sprintf(
+                'php %s/bin/php-dep %s --format=text --text-item-prefix="@"',
+                dirname(__DIR__),
+                $mainFile
+            );
+            
+            $customOutput = shell_exec($customCommand);
+            
+            $this->assertStringContainsString('@', $customOutput);
+            $this->assertStringNotContainsString('  - ', $customOutput);
+            
+        } finally {
+            // Clean up
+            if (file_exists($mainFile)) {
+                unlink($mainFile);
+            }
+            if (file_exists($depFile)) {
+                unlink($depFile);
+            }
+            if (is_dir($tempDir)) {
+                rmdir($tempDir);
+            }
+        }
+    }
+
+    /**
+     * Test text output with custom empty item prefix
+     */
+    public function testTextOutputWithCustomEmptyPrefix()
+    {
+        // Create a temporary directory for test files
+        $tempDir = sys_get_temp_dir() . '/php-dep-test-' . uniqid();
+        mkdir($tempDir, 0755, true);
+        
+        try {
+            // Create test files
+            $mainFile = $tempDir . '/main.php';
+            $depFile = $tempDir . '/dependency.php';
+            
+            file_put_contents($mainFile, '<?php require_once "dependency.php"; echo "Main file"; ?>');
+            file_put_contents($depFile, '<?php echo "Dependency file"; ?>');
+            
+            $emptyCommand = sprintf(
+                'php %s/bin/php-dep %s --format=text --text-item-prefix=""',
+                dirname(__DIR__),
+                $mainFile
+            );
+            
+            $emptyOutput = shell_exec($emptyCommand);
+            
+            $this->assertStringContainsString('Dependencies for', $emptyOutput);
+            $this->assertStringNotContainsString('  - ', $emptyOutput);
+            
+        } finally {
+            // Clean up
+            if (file_exists($mainFile)) {
+                unlink($mainFile);
+            }
+            if (file_exists($depFile)) {
+                unlink($depFile);
+            }
+            if (is_dir($tempDir)) {
+                rmdir($tempDir);
+            }
+        }
+    }
 }


### PR DESCRIPTION
テキスト出力形式のファイル一覧のプレフィックスを指定することができる `--text-item-prefix` オプションを追加します。
テキスト出力形式のカスタマイズが可能になり、LLM などの他ツールと連携する際に有用な出力形式を生成できるようになります。